### PR TITLE
fix: wrong carla project name; add: MIT LICENSE into carla_apollo_bridge

### DIFF
--- a/carla/docker_run_carla.sh
+++ b/carla/docker_run_carla.sh
@@ -1,1 +1,1 @@
-docker-compose -f carla-compose.yml  -p carla_0.9.13  up -d
+docker-compose -f carla-compose.yml  -p carla  up -d

--- a/carla_apollo_bridge/LICENSE
+++ b/carla_apollo_bridge/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Casper Auto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Add: MIT license into carla_apollo_bridge
Fix: wrong carla project name