### PR TITLE
bug fix: ctrl+c can't interrupt the bridge

### DIFF
--- a/carla_bridge/main.py
+++ b/carla_bridge/main.py
@@ -213,6 +213,8 @@ def main():
         settings.fixed_delta_seconds = None
         carla_world.apply_settings(settings)
         log.warning("Shutting down.")
+        if carla_bridge.shutdown :
+            carla_bridge.shutdown.set()
         carla_bridge.destroy()
         del carla_world
         del carla_client


### PR DESCRIPTION
# Description

<!--
Please explain the changes you've made.
-->
In the `finally` stage after the bridge `exception`, set the status for the carla_bridge.shutdown event
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

I noticed that the bridge could not be closed normally through ctrl+c. By checking- the code, I found that the shutdown event was not set correctly at all.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing

[//]: # (* [ ] Extended the documentation / Created issue in the https://github.com/guardstrikelab/docs/ repo: guardstrikelab/docs#_[issue number]_)
[//]: # (* [ ] Specification has been updated / Created issue in the https://github.com/guardstrikelab/docs/ repo: guardstrikelab/docs#_[issue number]_)
[//]: # (* [ ] Provided sample for the feature / Created issue in the https://github.com/guardstrikelab/docs/ repo: guardstrikelab/docs#_[issue number]_)
